### PR TITLE
Prevent workspace idling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM debian:10.5
 
 RUN echo "deb http://ftp.debian.org/debian/ testing main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y git supervisor tightvncserver wget openjdk-11-jdk ttf-mscorefonts-installer vnc4server novnc fluxbox && apt-get clean
+    apt-get update && apt-get install -y git supervisor tightvncserver wget openjdk-11-jdk ttf-mscorefonts-installer vnc4server novnc fluxbox curl && apt-get clean
 RUN mkdir /ideaIC-2020.2.2 && wget -qO- https://download.jetbrains.com/idea/ideaIC-2020.2.2.tar.gz | tar -zxv --strip-components=1 -C /ideaIC-2020.2.2 && \
     mkdir /intellij-config && \
     for f in "/intellij-config" "/ideaIC-2020.2.2" "/etc/passwd"; do \
@@ -20,9 +20,10 @@ RUN mkdir /ideaIC-2020.2.2 && wget -qO- https://download.jetbrains.com/idea/idea
 COPY --chown=0:0 entrypoint.sh /entrypoint.sh
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 COPY entrypoint.sh /
+COPY prevent-idle-timeout.sh /
 COPY supervisord.conf /etc/supervisord.conf
 COPY fluxbox /etc/X11/fluxbox/init
-RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh
+RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh && chmod +x /prevent-idle-timeout.sh
 USER 10001
 ENV HOME=/home/user
 WORKDIR /projects

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ if ! whoami &> /dev/null; then
     echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
   fi
 fi
+
 cat /etc/passwd
 id
 /usr/bin/supervisord -c /etc/supervisord.conf

--- a/prevent-idle-timeout.sh
+++ b/prevent-idle-timeout.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Ensure that main environment variable are configured
+if [ -z "${CHE_API_INTERNAL}" ]; then
+    echo "CHE_API_INTERNAL is not configured in environment."
+    exit 1
+fi
+if [ -z "${CHE_MACHINE_TOKEN}" ]; then
+    echo "CHE_MACHINE_TOKEN is not configured in environment."
+    exit 1
+fi
+if [ -z "${CHE_WORKSPACE_ID}" ]; then
+    echo "CHE_WORKSPACE_ID is not configured in environment."
+    exit 1
+fi
+
+# Todo(vzhukovs): check for client certificates that might be included into request in case if script runs on minikube with self-signed certificates
+
+# Start making requests to avoid idling, make a request to activity tracker each minute
+while true; do
+    curl -X PUT \
+    -H "Authorization: Bearer ${CHE_MACHINE_TOKEN}" \
+    "${CHE_API_INTERNAL}/activity/${CHE_WORKSPACE_ID}"
+
+    sleep 1m
+done

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -30,3 +30,8 @@ user=user
 autorestart=true
 priority=500
 
+[program:prevent-ide-timeout]
+command=/prevent-idle-timeout.sh
+user=user
+autorestart=true
+priority=500


### PR DESCRIPTION
This changes proposal adds a simple script which prevents workspace idling by making a request to workspace master each minute. At first step it doesn't take into account a client certificates which might be located on file system in case if Che runs on minikube with using self-signed certificates (which is marked by a todo in [entrypoint.sh](https://github.com/che-incubator/che-editor-intellij-community/compare/master...vzhukovskii:prevent-workspace-idling?expand=1#diff-b958f585a04af5ee2087610ea7180f34R45)). With this approach user has to stop the workspace by himself.

<img width="1254" alt="OpenShift Web Console 2020-09-25 14-57-42" src="https://user-images.githubusercontent.com/1968177/94264576-98373980-ff3f-11ea-8d7c-4c52b30c6e56.png">

Factory link to test: http://che.openshift.io/f?url=https://raw.githubusercontent.com/vzhukovskii/devfiles/master/workspace.yaml

Related issue: https://github.com/eclipse/che/issues/17953

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>