### PR TITLE
Build and publish latest tag

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -44,5 +44,6 @@ jobs:
           PLATFORMS=$(cat PLATFORMS)
           echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
           docker buildx build --platform "${PLATFORMS}" -t "${IMAGE_NAME}:${IMAGE_VERSION}-${SHORT_SHA1}" \
-            -t "${IMAGE_NAME}:latest" \
+            --push .
+          docker buildx build --platform "${PLATFORMS}" -t "${IMAGE_NAME}:latest" \
             --push .


### PR DESCRIPTION
Use dedicate build command for building and publishing the latest tag.