### PR TITLE
Storing Intellij Idea preferences between workspace restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ FROM debian:10.5
 RUN echo "deb http://ftp.debian.org/debian/ testing main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y git supervisor tightvncserver wget openjdk-11-jdk ttf-mscorefonts-installer vnc4server novnc fluxbox curl && apt-get clean
 RUN mkdir /ideaIC-2020.2.2 && wget -qO- https://download.jetbrains.com/idea/ideaIC-2020.2.2.tar.gz | tar -zxv --strip-components=1 -C /ideaIC-2020.2.2 && \
-    mkdir /intellij-config && \
-    for f in "/intellij-config" "/ideaIC-2020.2.2" "/etc/passwd"; do \
+    mkdir -p /JetBrains/IdeaIC && \
+    for f in "/JetBrains" "/ideaIC-2020.2.2" "/etc/passwd"; do \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
     done
@@ -23,9 +23,11 @@ COPY entrypoint.sh /
 COPY prevent-idle-timeout.sh /
 COPY supervisord.conf /etc/supervisord.conf
 COPY fluxbox /etc/X11/fluxbox/init
+COPY idea.properties /JetBrains/idea.properties
 RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh && chmod +x /prevent-idle-timeout.sh
 USER 10001
 ENV HOME=/home/user
+ENV IDEA_PROPERTIES=/JetBrains/idea.properties
 WORKDIR /projects
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["tail", "-f", "/dev/null"]

--- a/devfiles/meta.yaml
+++ b/devfiles/meta.yaml
@@ -25,14 +25,8 @@ spec:
      image: "quay.io/che-incubator/che-editor-intellij-community:latest"
      mountSources: true
      volumes:
-         - mountPath: "/intellij-config"
-           name: intellij-config     
-     volumes:
-         - mountPath: "/home/user/.local"
-           name: intellij-local
-     volumes:
-         - mountPath: "/home/user/.java"
-           name: intellij-java
+         - mountPath: "/JetBrains/IdeaIC"
+           name: idea-configuration
      ports:
          - exposedPort: 8080
      memoryLimit: "2048M"

--- a/idea.properties
+++ b/idea.properties
@@ -1,0 +1,4 @@
+idea.config.path=/JetBrains/IdeaIC/config
+idea.system.path=/JetBrains/IdeaIC/caches
+idea.plugins.path=/JetBrains/IdeaIC/plugins
+idea.log.path=/JetBrains/IdeaIC/logs


### PR DESCRIPTION
This changes proposal adds ability to store Intellij Idea preferences between workspace restart.

There is a new property file `idea.properties` introduced, located at path `/JetBrains/idea.properties` with the following content:
```properties
idea.config.path=/JetBrains/IdeaIC/config
idea.system.path=/JetBrains/IdeaIC/caches
idea.plugins.path=/JetBrains/IdeaIC/plugins
idea.log.path=/JetBrains/IdeaIC/logs
```

Directory `/JetBrains/IdeaIC` is mounted via volume mount in meta.yaml. Which contains at this moment configuration, plugins and local cache.

The main restriction in this flow is that we can provide only one volume mount in container, so `intellij-local` volume mount was removed, because it can be configured via `idea.plugins.path` property. See the [doc](https://www.jetbrains.com/help/idea/tuning-the-ide.html#plugins-directory). The same situation with `intellij-java` volume mount.

Short demo: https://drive.google.com/file/d/17y8fgV0WdBh86VYbQ6F6Z3hw9bqqGrPR/view?usp=sharing

Devfile to test:
```
metadata:
  name: vzhukovs-intellij
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/vzhukovskii/1f318906827da2ca89b5a9bb306ea8ef/raw/7536968f8f267d4a9edb7ff76eea624009ad423a/meta.yaml
    alias: theia-editor
apiVersion: 1.0.0

```

Related issue: https://github.com/eclipse/che/issues/17968