### PR TITLE
Provide preliminary configuration for Intellij Idea

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,16 @@ RUN yum install -y tigervnc-server supervisor wget java-11-openjdk-devel novnc f
 
 RUN mkdir /ideaIC-2020.2.2 && wget -qO- https://download.jetbrains.com/idea/ideaIC-2020.2.2.tar.gz | tar -zxv --strip-components=1 -C /ideaIC-2020.2.2 && \
     mkdir -p /JetBrains/IdeaIC && \
-    for f in "/JetBrains" "/ideaIC-2020.2.2" "/etc/passwd"; do \
+    mkdir /etc/default/jetbrains && \
+    for f in "/JetBrains" "/ideaIC-2020.2.2" "/etc/passwd" "/etc/default/jetbrains"; do \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
     done
 
-COPY --chown=0:0 /etc/entrypoint.sh /entrypoint.sh
+COPY --chown=0:0 etc/entrypoint.sh /entrypoint.sh
 COPY --chown=0:0 etc/prevent-idle-timeout.sh /
+COPY --chown=0:0 etc/preliminary-configuration.sh /
+COPY --chown=0:0 etc/default/*.xml /etc/default/jetbrains/
 COPY --chown=0:0 etc/supervisord.conf /etc/supervisord.conf
 # disable toolbar + use another theme
 COPY --chown=0:0 etc/fluxbox /home/user/.fluxbox/init
@@ -26,7 +29,7 @@ COPY --chown=0:0 etc/fluxbox /home/user/.fluxbox/init
 COPY etc/tigervnc-config /etc/tigervnc/vncserver-config-mandatory
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 COPY idea.properties /JetBrains/idea.properties
-RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh && chmod +x /prevent-idle-timeout.sh
+RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh && chmod +x /prevent-idle-timeout.sh && chmod +x /preliminary-configuration.sh
 USER 10001
 ENV HOME=/home/user
 ENV IDEA_PROPERTIES=/JetBrains/idea.properties

--- a/etc/default/ide.general.xml
+++ b/etc/default/ide.general.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="GeneralSettings">
+    <option name="defaultProjectDirectory" value="/projects" />
+  </component>
+</application>

--- a/etc/default/other.xml
+++ b/etc/default/other.xml
@@ -1,0 +1,6 @@
+<application>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="/projects" />
+    <property name="terminalCustomCommandExecutionTurnOff" value="false" />
+  </component>
+</application>

--- a/etc/preliminary-configuration.sh
+++ b/etc/preliminary-configuration.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+if [ ! -e /JetBrains/IdeaIC/config/options ]; then
+    mkdir -p /JetBrains/IdeaIC/config/options
+    echo "Provide preliminary Intellij Idea configuration"
+    cp /etc/default/jetbrains/other.xml /JetBrains/IdeaIC/config/options/other.xml
+    cp /etc/default/jetbrains/ide.general.xml /JetBrains/IdeaIC/config/options/ide.general.xml
+fi

--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -10,6 +10,12 @@ user=user
 autorestart=false
 priority=300
 
+[program:preliminary-idea-configuration]
+command=/preliminary-configuration.sh
+user=user
+autorestart=false
+priority=350
+
 [program:idea]
 environment=DISPLAY=":0"
 command=/ideaIC-2020.2.2/bin/idea.sh


### PR DESCRIPTION
This changes proposal provides default settings at workspace creation step for:
`Appearance & Behavior > System Settings > Project > Default project directory` to `/projects`
`Tools > Terminal > Run Commands using IDE` to `false`

Related issue: https://github.com/eclipse/che/issues/17986

<img width="1720" alt="Eclipse Che hosted by Red Hat | vzhukovs-intellij-4 2020-09-30 16-34-51" src="https://user-images.githubusercontent.com/1968177/94692722-88eb2e00-033b-11eb-90c9-5a7e34703206.png">
<img width="1720" alt="Eclipse Che hosted by Red Hat | vzhukovs-intellij-4 2020-09-30 16-35-35" src="https://user-images.githubusercontent.com/1968177/94692736-8ee10f00-033b-11eb-9c84-e38d205a74e0.png">

Devfile to test:
```
metadata:
  name: vzhukovs-intellij-1
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/vzhukovskii/1f318906827da2ca89b5a9bb306ea8ef/raw/7536968f8f267d4a9edb7ff76eea624009ad423a/meta.yaml
    alias: theia-editor
apiVersion: 1.0.0
```
